### PR TITLE
Make pip install quiet in the nightly build

### DIFF
--- a/tools/ci/run_tests.sh
+++ b/tools/ci/run_tests.sh
@@ -17,8 +17,8 @@ set -e
 
 PROJECT_DIR=$(cd "$(dirname "$0")/../.."; pwd)
 
-python -m pip install apache-flink==1.15.2
-python -m pip install --upgrade feathub-nightly
+python -m pip -q install apache-flink==1.15.2
+python -m pip -q install --upgrade feathub-nightly
 
 # Run the run_and_verify.sh script in each example folder
 for EXAMPLE_RUN_SCRIPT in "${PROJECT_DIR}"/*/run_and_verify.sh; do


### PR DESCRIPTION
This PR add the `-q` option to hide the output from the pip install.