### PR TITLE
Add flink-read-write-redis example

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,7 +1,11 @@
-name: Nightly Build
+name: Build And Test
 on:
   schedule:
     - cron: '0 20 * * *'
+  push:
+  pull_request:
+    branches:
+      - '**'
   workflow_dispatch:
     inputs:
       debug_enabled:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,17 +3,36 @@ FROM flink:1.15.2
 ENV HADOOP_VERSION=3.2.4
 ENV PATH=/opt/hadoop-$HADOOP_VERSION/bin/:$PATH
 
-# Downloads and extracts hadoop binary
+# Download and extract hadoop binary
 WORKDIR /opt
 RUN curl -O https://dlcdn.apache.org/hadoop/common/hadoop-$HADOOP_VERSION/hadoop-$HADOOP_VERSION.tar.gz && \
     tar -xzvf hadoop-$HADOOP_VERSION.tar.gz
 
-# Installs flink plugins
+# Install flink plugins
 WORKDIR ${FLINK_HOME}
 RUN mkdir plugins/oss-fs-hadoop && \
     mkdir plugins/s3-fs-hadoop && \
     ln -s ../../opt/flink-oss-fs-hadoop-1.15.2.jar plugins/oss-fs-hadoop/flink-oss-fs-hadoop-1.15.2.jar && \
     ln -s ../../opt/flink-s3-fs-hadoop-1.15.2.jar plugins/s3-fs-hadoop/flink-s3-fs-hadoop-1.15.2.jar
+
+# Install python3.7. This is because flink:1.15.2 docker image has been upgraded to use Debian 11 which
+# uses Python 3.9. But PyFlink only supports Python 3.6, 3.7 and 3.8.
+RUN apt-get update -y && \
+apt-get install -y build-essential libssl-dev zlib1g-dev libbz2-dev libffi-dev && \
+wget https://www.python.org/ftp/python/3.7.9/Python-3.7.9.tgz && \
+tar -xvf Python-3.7.9.tgz && \
+cd Python-3.7.9 && \
+./configure --without-tests --enable-shared && \
+make -j6 && \
+make install && \
+ldconfig /usr/local/lib && \
+cd .. && rm -f Python-3.7.9.tgz && rm -rf Python-3.7.9 && \
+ln -s /usr/local/bin/python3 /usr/local/bin/python && \
+apt-get clean && \
+rm -rf /var/lib/apt/lists/*
+
+# Install Feathub (and PyFlink)
+RUN pip3 install feathub-nightly
 
 # Further customization can be added.
 # You can refer to https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/resource-providers/standalone/docker/#further-customization.

--- a/flink-derived-feature-view/README.md
+++ b/flink-derived-feature-view/README.md
@@ -41,10 +41,9 @@ Prerequisites for running this example:
 Please execute the following commands under the `flink-derived-feature-view`
 folder to run this example.
 
-1. Install Feathub and Flink pip package.
+1. Install Feathub pip package.
 
    ```bash
-   $ python -m pip install apache-flink==1.15.2
    $ python -m pip install --upgrade feathub-nightly
    ```
 

--- a/flink-read-write-hdfs/README.md
+++ b/flink-read-write-hdfs/README.md
@@ -42,17 +42,16 @@ Prerequisites for running this example:
 Please execute the following commands under the `flink-read-write-hdfs`
 folder to run this example.
 
-1. Install Feathub and Flink pip package.
+1. Install Feathub pip package.
 
    ```bash
-   $ python -m pip install apache-flink==1.15.2
    $ python -m pip install --upgrade feathub-nightly
    ```
 
 2. Build the Flink image to support HDFS.
 
    ```bash
-   $ docker build --rm -t flink-with-filesystem -f ../docker/Dockerfile .
+   $ docker build --rm -t feathub-flink -f ../docker/Dockerfile .
    ```
 
 3. Start the Flink cluster and Hadoop cluster.

--- a/flink-read-write-hdfs/docker-compose.yaml
+++ b/flink-read-write-hdfs/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '2.1'
 services:
   flink:
-    image: flink-with-filesystem:latest
+    image: feathub-flink:latest
     command:
       - bash
       - -c

--- a/flink-read-write-hdfs/run_and_verify.sh
+++ b/flink-read-write-hdfs/run_and_verify.sh
@@ -20,8 +20,6 @@ cd "$(dirname "$0")"
 PROJECT_DIR=$(cd "$(pwd)/.."; pwd)
 source "${PROJECT_DIR}"/tools/utils.sh
 
-docker build --rm -t flink-with-filesystem -f ../docker/Dockerfile .
-
 chmod 777 data
 docker-compose up -d
 wait_for_port 8081 "Flink Cluster"

--- a/flink-read-write-redis/README.md
+++ b/flink-read-write-redis/README.md
@@ -1,0 +1,78 @@
+# Overview
+
+This example shows how to save input dataset with features into a Redis Cluster
+with `RedisSink`, and provides online serving based on the saved features with
+`RedisSource`. It involves the following steps:
+
+1. Read a batch of historical item price events from a file.
+
+   Each item price event has the following fields:
+   - item_id, unique identifier of the item.
+   - price, the new price of this item.
+   - timestamp, time when the new price is used for this item.
+
+2. For each item price event, save the event into a Redis cluster. If a feature
+   with the same item_id has been saved to Redis before, and the incoming event
+   has a larger timestamp than the existing one, Feathub would update the price
+   and timestamp values of the entry in Redis with that of the incoming event.
+
+3. Read the latest item prices from the Redis cluster and use them to create an
+   `OnDemandFeatureView` to provide online serving. In this example, the
+   features displayed by online serving are printed out in the terminal.
+
+# Prerequisites
+
+Prerequisites for running this example:
+- Unix-like operating system (e.g. Linux, Mac OS X)
+- Python 3.7
+
+# Step-By-Step Instructions
+
+Please execute the following commands under the `flink-read-write-redis` folder
+to run this example.
+
+1. Install Feathub pip package.
+
+   ```bash
+   $ python -m pip install --upgrade feathub-nightly
+   ```
+
+2. Build the Flink image with PyFlink support.
+
+   ```bash
+   $ docker build --rm -t feathub-flink -f ../docker/Dockerfile .
+   ```
+
+3. Start the Flink cluster and Redis cluster.
+
+   ```bash
+   $ docker-compose up -d
+   ```
+
+   After the Flink cluster has started, you should be able to navigate to the
+   web UI at [localhost:8081](http://localhost:8081) to view the Flink
+   dashboard.
+
+4. Run the FeatHub program to save the item price features to Redis and provide
+   online serving accordingly.
+
+   ```bash
+   $ python main.py
+   ```
+
+   You should be able to find the following information printed out in the end
+   of the terminal.
+
+   ```
+     item_id  price
+   0  item_1  400.0
+   1  item_2  200.0
+   2  item_3  300.0
+   ```
+
+5. Tear down the Flink cluster and Redis cluster after the FeatHub program has
+   finished.
+
+   ```bash
+   docker-compose down
+   ```

--- a/flink-read-write-redis/data/expected_output.csv
+++ b/flink-read-write-redis/data/expected_output.csv
@@ -1,0 +1,4 @@
+item_id,price
+item_1,400.0
+item_2,200.0
+item_3,300.0

--- a/flink-read-write-redis/data/item_price_events.json
+++ b/flink-read-write-redis/data/item_price_events.json
@@ -1,0 +1,6 @@
+{"item_id":"item_1", "price":100.0, "timestamp":"2022-01-01 00:00:00 +0800"}
+{"item_id":"item_2", "price":200.0, "timestamp":"2022-01-01 00:00:00 +0800"}
+{"item_id":"item_3", "price":300.0, "timestamp":"2022-01-01 00:00:00 +0800"}
+{"item_id":"item_1", "price":200.0, "timestamp":"2022-01-01 00:01:30 +0800"}
+{"item_id":"item_1", "price":300.0, "timestamp":"2022-01-01 00:02:30 +0800"}
+{"item_id":"item_1", "price":400.0, "timestamp":"2022-01-01 00:03:30 +0800"}

--- a/flink-read-write-redis/docker-compose.yaml
+++ b/flink-read-write-redis/docker-compose.yaml
@@ -1,0 +1,25 @@
+version: '2.1'
+services:
+  redis:
+    image: docker.io/redis:7.0-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - "redis_data:/tmp/redis"
+  flink:
+    image: feathub-flink:latest
+    command:
+      - bash
+      - -c
+      - "./bin/start-cluster.sh; while true; do sleep 10; done"
+    ports:
+      - "8081:8081"
+    volumes:
+      - "flink_data:/tmp/flink"
+      - "./data:/tmp/data"
+
+volumes:
+  redis_data:
+    driver: local
+  flink_data:
+    driver: local

--- a/flink-read-write-redis/main.py
+++ b/flink-read-write-redis/main.py
@@ -1,0 +1,104 @@
+#  Copyright 2022 The Feathub Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import numpy as np
+import pandas as pd
+from feathub.common import types
+from feathub.feathub_client import FeathubClient
+from feathub.feature_tables.sinks.redis_sink import RedisSink
+from feathub.feature_tables.sources.file_system_source import FileSystemSource
+from feathub.feature_tables.sources.redis_source import RedisSource
+from feathub.feature_views.on_demand_feature_view import OnDemandFeatureView
+from feathub.table.schema import Schema
+
+if __name__ == "__main__":
+    client = FeathubClient(
+        props={
+            "processor": {
+                "type": "flink",
+                "flink": {"rest.address": "localhost", "rest.port": 8081},
+            },
+            "online_store": {
+                "types": ["memory"],
+                "memory": {},
+            },
+            "registry": {
+                "type": "local",
+                "local": {
+                    "namespace": "default",
+                },
+            },
+            "feature_service": {
+                "type": "local",
+                "local": {},
+            },
+        }
+    )
+
+    item_price_events_schema = (
+        Schema.new_builder()
+        .column("item_id", types.String)
+        .column("price", types.Float32)
+        .column("timestamp", types.String)
+        .build()
+    )
+
+    item_price_events_source = FileSystemSource(
+        name="item_price_events",
+        path="/tmp/data/item_price_events.json",
+        data_format="json",
+        schema=item_price_events_schema,
+        keys=["item_id"],
+        timestamp_field="timestamp",
+        timestamp_format="%Y-%m-%d %H:%M:%S %z",
+    )
+
+    result_table = client.get_features(item_price_events_source)
+
+    redis_sink = RedisSink(
+        host="redis",
+    )
+
+    result_table.execute_insert(sink=redis_sink, allow_overwrite=True).wait()
+
+    item_price_features_source = RedisSource(
+        name="item_price_features",
+        schema=item_price_events_schema,
+        keys=["item_id"],
+        host="localhost",
+        timestamp_field="timestamp",
+    )
+
+    on_demand_feature_view = OnDemandFeatureView(
+        name="on_demand_feature_view",
+        features=[
+            "item_price_features.price",
+        ],
+    )
+    client.build_features([item_price_features_source, on_demand_feature_view])
+
+    request_df = pd.DataFrame(
+        np.array([["item_1"], ["item_2"], ["item_3"]]), columns=["item_id"]
+    )
+
+    online_features = client.get_online_features(
+        request_df=request_df,
+        feature_view=on_demand_feature_view,
+    )
+
+    print(online_features)
+
+    expected_features = pd.read_csv("./data/expected_output.csv")
+    if not expected_features.equals(online_features):
+        raise RuntimeError("Online serving features does not match with expected.")

--- a/flink-read-write-redis/run_and_verify.sh
+++ b/flink-read-write-redis/run_and_verify.sh
@@ -13,17 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
 set -e
 
-PROJECT_DIR=$(cd "$(dirname "$0")/../.."; pwd)
+cd "$(dirname "$0")"
+PROJECT_DIR=$(cd "$(pwd)/.."; pwd)
+source "${PROJECT_DIR}"/tools/utils.sh
 
-python -m pip -q install --upgrade feathub-nightly
+chmod 777 data
+docker-compose up -d
+wait_for_port 8081 "Flink Cluster"
 
-docker build --rm -t feathub-flink -f ./docker/Dockerfile .
+python main.py
+exit_code=$?
+docker-compose down
 
-# Run the run_and_verify.sh script in each example folder
-for EXAMPLE_RUN_SCRIPT in "${PROJECT_DIR}"/*/run_and_verify.sh; do
-  echo "Running example ${EXAMPLE_RUN_SCRIPT}..."
-  bash "${EXAMPLE_RUN_SCRIPT}"
-  echo "Example ${EXAMPLE_RUN_SCRIPT} success."
-done
+exit $exit_code

--- a/flink-sliding-feature-view/README.md
+++ b/flink-sliding-feature-view/README.md
@@ -53,10 +53,9 @@ Prerequisites for running this example:
 Please execute the following commands under the `flink-sliding-feature-view`
 folder to run this example.
 
-1. Install Feathub and Flink pip package.
+1. Install Feathub pip package.
 
    ```bash
-   $ python -m pip install apache-flink==1.15.2
    $ python -m pip install --upgrade feathub-nightly
    ```
 


### PR DESCRIPTION
This pull request mainly adds an E2E example in the `flink-read-write-redis` directory, using Redis Source/Sink in Feathub projects.

This pull request also does the following:
- Add the installation process of PyFlink and Feathub in `docker/Dockerfile`.
  - The installation of PyFlink is referenced from https://nightlies.apache.org/flink/flink-docs-release-1.15/docs/deployment/resource-providers/standalone/docker/#using-flink-python-on-docker.
- Move the process to build up Feathub Docker image from `flink-read-write-hdfs` to root directory.
- Remove the installation guidelines of PyFlink.
- update github CI for `push` and `pull_request`.