### PR TITLE
Add PyFlink setup in DockerFile and link for HDFS/Redis examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This project provides example programs for key
 
 - [Flink - DerivedFeatureView](flink-derived-feature-view)
 - [Flink - SlidingFeatureView](flink-sliding-feature-view)
+- [Flink - Read and Write HDFS](flink-read-write-hdfs)
+- [Flink - Read and Write Redis](flink-read-write-redis)
 
 
 ## Code Formatting Guide

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,8 +31,8 @@ ln -s /usr/local/bin/python3 /usr/local/bin/python && \
 apt-get clean && \
 rm -rf /var/lib/apt/lists/*
 
-# Install Feathub (and PyFlink)
-RUN pip3 install feathub-nightly
+# Install Feathub with FlinkProcessor dependencies
+RUN pip3 install feathub-nightly[flink]
 
 # Further customization can be added.
 # You can refer to https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/resource-providers/standalone/docker/#further-customization.

--- a/flink-derived-feature-view/README.md
+++ b/flink-derived-feature-view/README.md
@@ -41,10 +41,10 @@ Prerequisites for running this example:
 Please execute the following commands under the `flink-derived-feature-view`
 folder to run this example.
 
-1. Install Feathub pip package.
+1. Install Feathub pip package with FlinkProcessor dependencies.
 
    ```bash
-   $ python -m pip install --upgrade feathub-nightly
+   $ python -m pip install --upgrade "feathub-nightly[flink]"
    ```
 
 2. Start the Flink cluster.

--- a/flink-read-write-hdfs/README.md
+++ b/flink-read-write-hdfs/README.md
@@ -42,10 +42,10 @@ Prerequisites for running this example:
 Please execute the following commands under the `flink-read-write-hdfs`
 folder to run this example.
 
-1. Install Feathub pip package.
+1. Install Feathub pip package with FlinkProcessor dependencies.
 
    ```bash
-   $ python -m pip install --upgrade feathub-nightly
+   $ python -m pip install --upgrade "feathub-nightly[flink]"
    ```
 
 2. Build the Flink image to support HDFS.

--- a/flink-read-write-redis/README.md
+++ b/flink-read-write-redis/README.md
@@ -31,10 +31,10 @@ Prerequisites for running this example:
 Please execute the following commands under the `flink-read-write-redis` folder
 to run this example.
 
-1. Install Feathub pip package.
+1. Install Feathub pip package with FlinkProcessor dependencies.
 
    ```bash
-   $ python -m pip install --upgrade feathub-nightly
+   $ python -m pip install --upgrade "feathub-nightly[flink]"
    ```
 
 2. Build the Flink image with PyFlink support.

--- a/flink-sliding-feature-view/README.md
+++ b/flink-sliding-feature-view/README.md
@@ -53,10 +53,10 @@ Prerequisites for running this example:
 Please execute the following commands under the `flink-sliding-feature-view`
 folder to run this example.
 
-1. Install Feathub pip package.
+1. Install Feathub pip package with FlinkProcessor dependencies.
 
    ```bash
-   $ python -m pip install --upgrade feathub-nightly
+   $ python -m pip install --upgrade "feathub-nightly[flink]"
    ```
 
 2. Start the Flink and the Kafka cluster.

--- a/tools/ci/run_tests.sh
+++ b/tools/ci/run_tests.sh
@@ -17,7 +17,7 @@ set -e
 
 PROJECT_DIR=$(cd "$(dirname "$0")/../.."; pwd)
 
-python -m pip -q install --upgrade feathub-nightly
+python -m pip -q install --upgrade "feathub-nightly[flink]"
 
 docker build --rm -t feathub-flink -f ./docker/Dockerfile .
 


### PR DESCRIPTION
In alibaba/feathub#57, the structure of Feathub Python library is modified. Now `pip install feathub-nightly` would only install requirements for Feathub common modules and local processor, leaving alone dependencies for Flink/Spark processor.

This PR modifies the installation process of Feathub in DockerFile and example documents, adding instructions to install dependencies for Flink processor. Dependencies for Spark processor are not installed in this PR. These dependencies should be installed when SparkProcessor examples are to be introduced.

This PR also fixes the missing link for HDFS/Redis examples in README.