### PR TITLE
Disable nightly build for fork repo and suppress the docker build output

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -16,6 +16,7 @@ on:
 jobs:
   run-examples:
     runs-on: ubuntu-20.04
+    if: github.repository == 'flink-extended/feathub-examples' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v3
       - name: Set up python 3.7

--- a/tools/ci/run_tests.sh
+++ b/tools/ci/run_tests.sh
@@ -19,7 +19,7 @@ PROJECT_DIR=$(cd "$(dirname "$0")/../.."; pwd)
 
 python -m pip -q install --upgrade "feathub-nightly[flink]"
 
-docker build --rm -t feathub-flink -f ./docker/Dockerfile .
+docker build -q --rm -t feathub-flink -f ./docker/Dockerfile .
 
 # Run the run_and_verify.sh script in each example folder
 for EXAMPLE_RUN_SCRIPT in "${PROJECT_DIR}"/*/run_and_verify.sh; do


### PR DESCRIPTION
The fork of this repo might not be update-to-date and its nightly build can break if we update feathub-nightly. And it is also unnecessary for all forks to run nightly build. This PR disables the nightly build for fork repo to address this issue.

Another issue is that the nightly build log (e.g. [this](https://github.com/flink-extended/feathub-examples/actions/runs/3920124707/jobs/6701556793)) contains a super long log from "docker build". Thus this PR suppresses the docker build output with the `-q` option.