### PR TITLE
Fix Flink master configuration

### DIFF
--- a/flink-derived-feature-view/main.py
+++ b/flink-derived-feature-view/main.py
@@ -31,7 +31,9 @@ if __name__ == "__main__":
         props={
             "processor": {
                 "type": "flink",
-                "flink": {"rest.address": "localhost", "rest.port": 8081},
+                "flink": {
+                    "master": "localhost:8081",
+                },
             },
             "online_store": {
                 "types": ["memory"],

--- a/flink-read-write-hdfs/main.py
+++ b/flink-read-write-hdfs/main.py
@@ -31,7 +31,9 @@ if __name__ == "__main__":
         props={
             "processor": {
                 "type": "flink",
-                "flink": {"rest.address": "localhost", "rest.port": 8081},
+                "flink": {
+                    "master": "localhost:8081",
+                },
             },
             "online_store": {
                 "types": ["memory"],

--- a/flink-read-write-mysql/main.py
+++ b/flink-read-write-mysql/main.py
@@ -28,8 +28,7 @@ if __name__ == "__main__":
             "processor": {
                 "type": "flink",
                 "flink": {
-                    "rest.address": "localhost",
-                    "rest.port": 8081,
+                    "master": "localhost:8081",
                 },
             },
             "online_store": {

--- a/flink-read-write-redis/main.py
+++ b/flink-read-write-redis/main.py
@@ -27,7 +27,9 @@ if __name__ == "__main__":
         props={
             "processor": {
                 "type": "flink",
-                "flink": {"rest.address": "localhost", "rest.port": 8081},
+                "flink": {
+                    "master": "localhost:8081",
+                },
             },
             "online_store": {
                 "types": ["memory"],

--- a/flink-sliding-feature-view-benchmark/main.py
+++ b/flink-sliding-feature-view-benchmark/main.py
@@ -33,7 +33,9 @@ def run(records_num: int):
         props={
             "processor": {
                 "type": "flink",
-                "flink": {"rest.address": "localhost", "rest.port": 8081},
+                "flink": {
+                    "master": "localhost:8081",
+                },
             },
             "online_store": {
                 "types": ["memory"],

--- a/flink-sliding-feature-view/initialize_kafka_topic.py
+++ b/flink-sliding-feature-view/initialize_kafka_topic.py
@@ -25,7 +25,9 @@ if __name__ == "__main__":
         props={
             "processor": {
                 "type": "flink",
-                "flink": {"rest.address": "localhost", "rest.port": 8081},
+                "flink": {
+                    "master": "localhost:8081",
+                },
             },
             "online_store": {
                 "types": ["memory"],

--- a/flink-sliding-feature-view/main.py
+++ b/flink-sliding-feature-view/main.py
@@ -32,7 +32,9 @@ if __name__ == "__main__":
         props={
             "processor": {
                 "type": "flink",
-                "flink": {"rest.address": "localhost", "rest.port": 8081},
+                "flink": {
+                    "master": "localhost:8081",
+                },
             },
             "online_store": {
                 "types": ["memory"],

--- a/flink-sql-feature-view/main.py
+++ b/flink-sql-feature-view/main.py
@@ -28,8 +28,7 @@ if __name__ == "__main__":
             "processor": {
                 "type": "flink",
                 "flink": {
-                    "rest.address": "localhost",
-                    "rest.port": 8081
+                    "master": "localhost:8081",
                 },
             },
             "online_store": {


### PR DESCRIPTION
This pull request fixes the failure in Action after FlinkProcessor changes its configuration from `rest.address` and `rest.port` into `master`.

The correctness of the repo after this pull request has been verified as shown in [this link](https://github.com/yunfengzhou-hub/feathub-examples/actions/runs/4718806185).