### PR TITLE
Fix kafka example timeout error

### DIFF
--- a/flink-kafka-join-filesystem/docker-compose.yaml
+++ b/flink-kafka-join-filesystem/docker-compose.yaml
@@ -1,16 +1,5 @@
 version: '2.1'
 services:
-  flink:
-    image: apache/flink:1.16.1
-    command:
-      - bash
-      - -c
-      - "./bin/start-cluster.sh; while true; do sleep 10; done"
-    ports:
-      - "8081:8081"
-    volumes:
-      - "flink_data:/tmp/flink"
-      - "./data:/tmp/data"
   zookeeper:
     image: docker.io/bitnami/zookeeper:3.8
     ports:
@@ -36,6 +25,18 @@ services:
       - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=CLIENT
     depends_on:
       - zookeeper
+  flink:
+    image: apache/flink:1.16.1
+    command:
+      - bash
+      - -c
+      - "./bin/start-cluster.sh; while true; do sleep 10; done"
+    ports:
+      - "8081:8081"
+    volumes:
+      - "flink_data:/tmp/flink"
+      - "./data:/tmp/data"
+
 volumes:
   zookeeper_data:
     driver: local

--- a/flink-kafka-join-filesystem/run_and_verify.sh
+++ b/flink-kafka-join-filesystem/run_and_verify.sh
@@ -38,7 +38,7 @@ while true; do
     --bootstrap-server localhost:9093 \
     --topic enriched_user_behavior_events \
     --from-beginning \
-    --timeout-ms 1000 > data/kafka-output
+    --timeout-ms 10000 > data/kafka-output
   if [ "$(wc -l < data/kafka-output)" -ge 10 ]; then
     break
   fi;

--- a/flink-sliding-feature-view/run_and_verify.sh
+++ b/flink-sliding-feature-view/run_and_verify.sh
@@ -38,7 +38,7 @@ while true; do
     --bootstrap-server localhost:9093 \
     --topic user_online_features \
     --from-beginning \
-    --timeout-ms 1000 > data/kafka-output
+    --timeout-ms 10000 > data/kafka-output
   if [ "$(wc -l < data/kafka-output)" -ge 5 ]; then
     break
   fi;


### PR DESCRIPTION
This pull request fixes the kafka example timeout error appeared in nightly builds[1~3] by increasing the timeout when reading kafka data from local host.

The correctness after this change is verified in [4], which repeated executing this example 10 times and all of them passed.

[1] https://github.com/flink-extended/feathub-examples/actions/runs/5106213310
[2] https://github.com/flink-extended/feathub-examples/actions/runs/5100590396
[3] https://github.com/flink-extended/feathub-examples/actions/runs/5094632076
[4] https://github.com/yunfengzhou-hub/feathub-examples/actions/runs/5118786431
