### PR TITLE
Add parameter values for hive data_format

### DIFF
--- a/flink-read-write-hive/main.py
+++ b/flink-read-write-hive/main.py
@@ -70,6 +70,7 @@ if __name__ == "__main__":
         hive_catalog_conf_dir=".",
         database="default",
         table="item_price_events",
+        data_format="parquet",
         processor_specific_props={
             "sink.partition-commit.watermark-time-zone": "Asia/Shanghai",
             "sink.partition-commit.policy.kind": "metastore,success-file",
@@ -83,6 +84,7 @@ if __name__ == "__main__":
         database="default",
         table="item_price_events",
         schema=item_price_events_schema,
+        data_format="parquet",
         keys=["item_id"],
         hive_catalog_conf_dir=".",
     )


### PR DESCRIPTION
Given that the latest master code of Feahtub has required Hive connectors to specify data format, this PR adds this parameter value when creating Hive source/sinks.